### PR TITLE
Fixed wmic invalid query commands in autounattend

### DIFF
--- a/builds/windows/server/2019/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/server/2019/data/autounattend.pkrtpl.hcl
@@ -207,7 +207,7 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Description>Set local account to not expire</Description>
-                    <CommandLine>cmd.exe /c wmic useraccount where "name=${ build_username }" set PasswordExpires=FALSE</CommandLine>
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='${ build_username }'" set PasswordExpires=FALSE</CommandLine>
                     <Order>3</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">

--- a/builds/windows/server/2022/data/autounattend.pkrtpl.hcl
+++ b/builds/windows/server/2022/data/autounattend.pkrtpl.hcl
@@ -207,7 +207,7 @@
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">
                     <Description>Set local account to not expire</Description>
-                    <CommandLine>cmd.exe /c wmic useraccount where "name=${ build_username }" set PasswordExpires=FALSE</CommandLine>
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='${ build_username }'" set PasswordExpires=FALSE</CommandLine>
                     <Order>3</Order>
                 </SynchronousCommand>
                 <SynchronousCommand wcm:action="add">


### PR DESCRIPTION
Resolves an invalid query when setting the build user password to not expire.